### PR TITLE
add support to ignore block regeneration in faction's wilderness

### DIFF
--- a/src/com/nitnelave/CreeperHeal/CreeperHeal.java
+++ b/src/com/nitnelave/CreeperHeal/CreeperHeal.java
@@ -127,6 +127,7 @@ public class CreeperHeal extends JavaPlugin {
 	private CreeperEconomy cEconomy;
 	private CreeperLog warningLog;
 	protected CreeperMessenger messenger;
+	private FactionHandler factionHandler;
 
 
 
@@ -236,6 +237,10 @@ public class CreeperHeal extends JavaPlugin {
 			 log_info("Successfully hooked in CreeperTrap", 0);
 		 }
 
+		 factionHandler = new FactionHandler(pm);
+		 if (factionHandler.isFactionsEnabled()) {
+			 log_info("Successfully hooked in Factions",0);
+		 }
 
 		 pm.registerEvents(listener, this);
 
@@ -1389,6 +1394,10 @@ public class CreeperHeal extends JavaPlugin {
 	public void refund(Player p, double amount) throws VaultNotDetectedException, TransactionFailedException
 	{
 		cEconomy.refundPlayer(p, amount); 
+	}
+
+	public FactionHandler getFactionHandler() {
+		return factionHandler;
 	}
 
 

--- a/src/com/nitnelave/CreeperHeal/CreeperListener.java
+++ b/src/com/nitnelave/CreeperHeal/CreeperListener.java
@@ -35,6 +35,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
 
 
+
 public class CreeperListener implements Listener{
 
 	private static CreeperHeal plugin;
@@ -51,6 +52,10 @@ public class CreeperListener implements Listener{
 			return;
 
 		WorldConfig world = getWorld(event.getLocation().getWorld());
+		
+		if (plugin.getFactionHandler().shouldIgnore(event.blockList(), world)) {
+			return;
+		}
 
 		Entity entity = event.getEntity();
 		if(CreeperUtils.shouldReplace(entity, world))

--- a/src/com/nitnelave/CreeperHeal/FactionHandler.java
+++ b/src/com/nitnelave/CreeperHeal/FactionHandler.java
@@ -1,0 +1,48 @@
+package com.nitnelave.CreeperHeal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.block.Block;
+import org.bukkit.plugin.PluginManager;
+
+import com.massivecraft.factions.Board;
+import com.massivecraft.factions.FLocation;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.P;
+
+public class FactionHandler {
+
+	private boolean isFactionsEnabled = false;
+
+	public FactionHandler(PluginManager pluginManager) {
+		P factions = (P) pluginManager.getPlugin("Factions");
+		isFactionsEnabled = factions != null;
+	}
+	
+	public boolean shouldIgnore(List<Block> blockList, WorldConfig world) {
+		if (!isFactionsEnabled || !world.ignoreFactionsWilderness) {
+			return false;
+		}
+		
+		Set<FLocation> explosionLocs = new HashSet<FLocation>();
+		for (Block block : blockList)
+		{
+			explosionLocs.add(new FLocation(block));
+		}
+		for (FLocation loc : explosionLocs)
+		{
+			Faction faction = Board.getFactionAt(loc);
+			if (!faction.isNone()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public boolean isFactionsEnabled() {
+		return isFactionsEnabled;
+	}
+
+}

--- a/src/com/nitnelave/CreeperHeal/WorldConfig.java
+++ b/src/com/nitnelave/CreeperHeal/WorldConfig.java
@@ -14,13 +14,14 @@ public class WorldConfig {
 
 	public boolean enderman, replaceAbove, blockLava, blockTNT, blockIgnite, blockBlackList, 
 	blockSpawnEggs, blockPvP, warnLava, warnTNT, warnIgnite, warnBlackList, warnSpawnEggs, warnPvP, preventFireSpread, preventFireLava,
-	creepers, tnt, fire, ghast, magical, dragons;
+	creepers, tnt, fire, ghast, magical, dragons, ignoreFactionsWilderness;
 	public String name;
 	public int repairTime, replaceLimit;
 	public ArrayList<BlockId> blockList = new ArrayList<BlockId>(), placeList = new ArrayList<BlockId>();
 	private File pluginFolder;
 	private YamlConfiguration config;
 	protected final Logger log = Logger.getLogger("Minecraft");            //to output messages to the console/log
+
 
 
 
@@ -35,8 +36,9 @@ public class WorldConfig {
 		else
 		{
 			creepers = tnt = ghast = fire = true;
-			magical = dragons = replaceAbove = enderman = blockLava = blockTNT = blockIgnite = blockBlackList = blockSpawnEggs = blockPvP= 
-					warnLava = warnTNT = warnIgnite = warnBlackList = warnSpawnEggs = warnPvP = preventFireSpread = preventFireLava = false;
+			magical = dragons = replaceAbove = enderman = blockLava = blockTNT = blockIgnite = blockBlackList = blockSpawnEggs = blockPvP = 
+					warnLava = warnTNT = warnIgnite = warnBlackList = warnSpawnEggs = warnPvP = preventFireSpread = preventFireLava =
+					ignoreFactionsWilderness = false;
 			replaceLimit = 60;
 			repairTime = -1;
 			blockList = new ArrayList<BlockId>();        //sample whitelist
@@ -62,7 +64,8 @@ public class WorldConfig {
 		blockList = (ArrayList<BlockId>) l[9];
 		repairTime = (Integer) l[10];
 		blockLava = blockTNT = blockIgnite = blockBlackList = blockSpawnEggs = blockPvP = warnLava = 
-		warnTNT = warnIgnite = warnBlackList = warnSpawnEggs = warnPvP = preventFireSpread = preventFireLava = false;
+		warnTNT = warnIgnite = warnBlackList = warnSpawnEggs = warnPvP = preventFireSpread = preventFireLava =
+		ignoreFactionsWilderness = false;
 		placeList = new ArrayList<BlockId>();
 	}
 
@@ -122,7 +125,7 @@ public class WorldConfig {
 		preventFireSpread = getBoolean("grief.prevent-fire-spread.fire", false);
 		preventFireLava = getBoolean("grief.prevent-fire-spread.lava", false);
 		placeList = loadList("grief.blacklist"); 
-
+		ignoreFactionsWilderness = getBoolean("replace.ignore-factions-wilderness", false);
 		
 	}
 	
@@ -154,7 +157,7 @@ public class WorldConfig {
 		set("grief.prevent-fire-spread.fire", preventFireSpread);
 		set("grief.prevent-fire-spread.lava", preventFireLava);
 		set("grief.blacklist", formatList(placeList)); 
-		
+		set("replace.ignore-factions-wilderness", ignoreFactionsWilderness);
 		config.save(pluginFolder.getPath() + "/" + name + ".yml");
 	}
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -58,6 +58,8 @@ world:
 #Minecraft time of the day at which everything should be healed (-1 to deactivate)
 #Sunrise is around 23000, noon 6000, sunset 13000, and midnight 18000. Day (zombies burning) starts at 0.
     repair-time-of-day: -1
+#Do not regenerate if Factions plugin enabled and explosion completely happens in Wilderness
+    ignore-factions-wilderness: false
 #
 #Grief prevention part
 #


### PR DESCRIPTION
In my factions server, I want to leave the mark of time on my landscape, but still let players build something beautiful. This change adds an option to ignore factions' wilderness for regeneration.

Tested on my home server and a public one, works fine if Factions is not found.

P.S. needs Factions plugin to build now.
