### PR TITLE
ignore data values when blocklist entry has none

### DIFF
--- a/src/com/nitnelave/CreeperHeal/block/ExplodedBlockManager.java
+++ b/src/com/nitnelave/CreeperHeal/block/ExplodedBlockManager.java
@@ -177,10 +177,9 @@ public class ExplodedBlockManager {
 			return;
 		}
 
-		if(world.whiteBlockList ^ !world.blockList.contains(new BlockId(type_id, data)))
+		if(world.whiteBlockList ^ !isBlocklisted(world, type_id, data))
 			//if the block is to be replaced
 		{
-
 			if(CreeperConfig.replaceProtectedChests && CreeperHeal.isProtected(block))
 				toReplace.put(block.getLocation(), block.getState());    //replace immediately
 
@@ -295,6 +294,27 @@ public class ExplodedBlockManager {
 
 	public static List<CreeperExplosion> getExplosionList() {
 		return explosionList;
+	}
+
+
+	/**
+	 * Check if a block with given type and data is blocklisted, ignoring
+	 * data if the blocklist entry lacks a data value
+	 */
+	private static boolean isBlocklisted(WorldConfig world, int type_id,
+			byte data) {
+		for(BlockId entry: world.blockList) {
+			if (entry.id == type_id) {
+				if (entry.hasData) {
+					if (entry.data == data) {
+						return true;
+					}
+				} else {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 

--- a/src/com/nitnelave/CreeperHeal/listeners/CreeperBlockListener.java
+++ b/src/com/nitnelave/CreeperHeal/listeners/CreeperBlockListener.java
@@ -45,10 +45,10 @@ public class CreeperBlockListener implements Listener{
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onHangingBreak(HangingBreakEvent e)
 	{
-		CreeperHeal.log.info("Hanging removed because of" + e.getCause());
 		if(e.isCancelled())
 			return;
 		
+		CreeperHeal.log.info("Hanging removed because of" + e.getCause());
 
 		Hanging h = (Hanging) e.getEntity();
 		if(e instanceof HangingBreakByEntityEvent)
@@ -224,7 +224,7 @@ public class CreeperBlockListener implements Listener{
 		
 		WorldConfig world = CreeperConfig.loadWorld(event.getLocation().getWorld());
 		
-		if (CreeperHeal.getFactionHandler().shouldIgnore(event.getLocation(), world)) {
+		if (CreeperHeal.getFactionHandler().shouldIgnore(event.blockList(), world)) {
 			return;
 		}
 

--- a/src/com/nitnelave/CreeperHeal/utils/FactionHandler.java
+++ b/src/com/nitnelave/CreeperHeal/utils/FactionHandler.java
@@ -1,6 +1,8 @@
 package com.nitnelave.CreeperHeal.utils;
 
-import org.bukkit.Location;
+import java.util.List;
+
+import org.bukkit.block.Block;
 import org.bukkit.plugin.PluginManager;
 
 import com.massivecraft.factions.Board;
@@ -17,12 +19,17 @@ public class FactionHandler {
 		isFactionsEnabled = factions != null;
 	}
 	
-	public boolean shouldIgnore(Location location, WorldConfig world) {
+	public boolean shouldIgnore(List<Block> list, WorldConfig world) {
 		if (!isFactionsEnabled || !world.ignoreFactionsWilderness) {
 			return false;
 		}
 		
-		return Board.getFactionAt(new FLocation(location)).isNone();	//don't replace if in Wilderness
+		for(Block block: list) {
+			if (!Board.getFactionAt(new FLocation(block.getLocation())).isNone()) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public boolean isFactionsEnabled() {


### PR DESCRIPTION
I added a simple method in ExplodedBlockManager that checks if block is in blocklist, ignoring data values only if the _blocklist_ entry does not specify a data value.
