### PR TITLE
Cursory fix for ExplosionRecordEvent.

### DIFF
--- a/src/main/java/com/nitnelave/CreeperHeal/block/ExplodedBlockManager.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/ExplodedBlockManager.java
@@ -172,9 +172,8 @@ public class ExplodedBlockManager
             return;
 
         //process list is the list of blocks yet to be processed by creeperheal.
-        List<Block> processList = new ArrayList<Block>();
-        processList.addAll(originalBlockList);
-        CHExplosionRecordEvent event = new CHExplosionRecordEvent(originalBlockList, processList, location, reason);
+        List<Block> processList = new ArrayList<Block>(originalBlockList);
+        CHExplosionRecordEvent event = new CHExplosionRecordEvent(processList, location, reason);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled())
             return;

--- a/src/main/java/com/nitnelave/CreeperHeal/events/CHExplosionRecordEvent.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/events/CHExplosionRecordEvent.java
@@ -13,22 +13,18 @@ import org.bukkit.event.HandlerList;
 /**
  * CHExplosionRecordEvent is fired as soon as CreeperHeal starts processing an
  * EntityExplodeEvent, listening allows you to manipulate the blocks which will
- * be exploded or healed.
+ * be or healed.
  **/
 public class CHExplosionRecordEvent extends Event implements Cancellable
 {
     private boolean cancelled = false;
     private static final HandlerList handlers = new HandlerList();
-    private List<Block> explosionBlocks;
     private List<Block> healBlocks;
-    private final ImmutableList<Block> originalExplosion;
     private final Location location;
     private final ExplosionReason reason;
 
-    public CHExplosionRecordEvent(List<Block> explosionBlocks, List<Block> healBlocks, Location location, ExplosionReason reason)
+    public CHExplosionRecordEvent(List<Block> healBlocks, Location location, ExplosionReason reason)
     {
-        this.explosionBlocks = explosionBlocks;
-        this.originalExplosion = ImmutableList.copyOf(explosionBlocks);
         this.healBlocks = healBlocks;
         this.location = location;
         this.reason = reason;
@@ -55,30 +51,6 @@ public class CHExplosionRecordEvent extends Event implements Cancellable
     public static HandlerList getHandlerList()
     {
         return handlers;
-    }
-
-    /**
-     * removing blocks from this list will remove them from the explosion
-     * protecting them.
-     * 
-     * Adding blocks to this list will include them in the explosion, blocks
-     * should then be added to the {@link #getHealBlocks} list to be healed by CreeperHeal.
-     * 
-     * Recommended to use {@link #protectBlock}  and {@link #naturalizeBlock} for readability.
-     *
-     * @return a mutable list of blocks that will be in the explosion.
-     **/
-    public List<Block> getExplosionBlocks()
-    {
-        return explosionBlocks;
-    }
-
-    /**
-     * @return An immutable list containing the blocks in the original explosion.
-     */
-    public ImmutableList<Block> getOriginalExplosionBlocks()
-    {
-        return originalExplosion;
     }
     
     /** 
@@ -131,25 +103,11 @@ public class CHExplosionRecordEvent extends Event implements Cancellable
     }
     
     /**
-     * Removes a block from the explosion protecting it, also prevents CreeperHeal
-     * processing the block.
-     **/
-    public void protectBlock(Block block)
-    {
-        if(explosionBlocks.contains(block))
-            explosionBlocks.remove(block);
-        if(healBlocks.contains(block))
-            healBlocks.remove(block);
-    }
-    
-    /**
      * Adds a block to the explosion, and adds it to the list for CreeperHeal to
      * process.
      */
     public void healBlock(Block block)
     {
-        if(!explosionBlocks.contains(block))
-            explosionBlocks.add(block);
         if(!healBlocks.contains(block))
             healBlocks.add(block);
     }
@@ -160,8 +118,6 @@ public class CHExplosionRecordEvent extends Event implements Cancellable
      */
     public void explodeBlock(Block block)
     {
-        if(!explosionBlocks.contains(block))
-            explosionBlocks.add(block);
         if(healBlocks.contains(block))
             healBlocks.remove(block);
     }


### PR DESCRIPTION
Probably needs more testing to ensure no side effects happen.
But it should be fine as long as creeperheal doesn't remove blocks from the original explosion list.
