### PR TITLE
Fixed double chest issue

### DIFF
--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperChest.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperChest.java
@@ -26,9 +26,9 @@ class CreeperChest extends CreeperBlock
 
     private final Block chest;
 
-    private NeighborChest neighbor = null;
+    private int size;
 
-    private ItemStack[] storedInventory = null, neighborInventory = null;
+    private ItemStack[] storedInventory = null;
 
     /*
      * Constructor.
@@ -39,20 +39,7 @@ class CreeperChest extends CreeperBlock
         chest = getBlock();
         Inventory inv = ((InventoryHolder) blockState).getInventory();
         storedInventory = inv.getContents();
-        if (inv.getType() == InventoryType.CHEST)
-        {
-            neighbor = scanForNeighborChest(chest.getState());
-            if (neighbor != null)
-            {
-                Inventory otherInv = neighbor.isRight() ? ((DoubleChestInventory) inv).getLeftSide()
-                                                       : ((DoubleChestInventory) inv).getRightSide();
-                Inventory mainInv = neighbor.isRight() ? ((DoubleChestInventory) inv).getRightSide()
-                                                      : ((DoubleChestInventory) inv).getLeftSide();
-
-                storedInventory = mainInv.getContents();
-                neighborInventory = otherInv.getContents();
-            }
-        }
+        size = inv.getContents().length;
     }
 
     /*
@@ -127,71 +114,10 @@ class CreeperChest extends CreeperBlock
         super.update();
         getBlock().setType(blockState.getType());
         getBlock().setData(blockState.getRawData());
-        if (!CreeperConfig.getWorld(getWorld()).getBool(WCfgVal.DROP_CHEST_CONTENTS))
-            try
-            {
-                if (hasNeighbor())
-                {
-                    neighbor.update(true);
-                    Inventory i = ((InventoryHolder) chest.getState()).getInventory();
-                    ItemStack[] both;
-                    ItemStack[] otherInv = neighborInventory;
-                    ItemStack[] newInv = storedInventory;
-                    if (neighbor.isRight())
-                        both = CreeperUtils.concat(otherInv, newInv);
-                    else
-                        both = CreeperUtils.concat(newInv, otherInv);
-                    i.setContents(both);
-
-                }
-                else
-                    ((InventoryHolder) chest.getState()).getInventory().setContents(storedInventory);
-            } catch (java.lang.ClassCastException e)
-            {
-                CreeperLog.warning("Error detected, please report the whole message");
-                CreeperLog.warning("ClassCastException when replacing a chest : ");
-                CreeperLog.warning(chest.getClass().getCanonicalName());
-                CreeperLog.displayBlockLocation(chest, true);
-                e.printStackTrace();
-            }
-        else if (hasNeighbor())
-            neighbor.getChest().update(true);
-
-    }
-
-    /*
-     * Get the other chest of the double chest. null if it is a simple chest.
-     */
-    private static NeighborChest scanForNeighborChest(BlockState block)
-    {
-        return scanForNeighborChest(block.getWorld(), block.getX(), block.getY(), block.getZ(), block.getRawData(), block.getType());
-    }
-
-    /*
-     * Get the other chest of the double chest. null if it is a simple chest.
-     */
-    private static NeighborChest scanForNeighborChest(World world, int x, int y, int z, short d,
-                                                      Material material)
-    {
-        Block neighbor;
-        if (d <= 3)
-        {
-            neighbor = world.getBlockAt(x - 1, y, z);
-            if (neighbor.getType().equals(material))
-                return new NeighborChest(neighbor, d == 3);
-            neighbor = world.getBlockAt(x + 1, y, z);
-            if (neighbor.getType().equals(material))
-                return new NeighborChest(neighbor, d == 2);
+        if(CreeperConfig.getWorld(getWorld()).getBool(WCfgVal.DROP_CHEST_CONTENTS) && getBlock().getState() instanceof InventoryHolder) {
+            InventoryHolder holder = (InventoryHolder) getBlock().getState();
+            Inventory inventory = holder.getInventory();
+            if(inventory.getContents().length == size) inventory.setContents(storedInventory);
         }
-        else
-        {
-            neighbor = world.getBlockAt(x, y, z - 1);
-            if (neighbor.getType().equals(material))
-                return new NeighborChest(neighbor, d == 4);
-            neighbor = world.getBlockAt(x, y, z + 1);
-            if (neighbor.getType().equals(material))
-                return new NeighborChest(neighbor, d == 5);
-        }
-        return null;
     }
 }


### PR DESCRIPTION
This should fix that bug. Alternatively, you can try removing the inventory.getType == CHEST check, as that may ignore the double chest thing, although I am not sure if it's the cause (This isn't tested, but I made my own plugin a long time ago that didn't handle huge amounts of blocks well, but it did work with double chests, and this method is faster as it doesn't check for neighboring chests, it just stores the inventory size and only sets the items if the inventory size is correct)