### PR TITLE
Some Bugfixes regarding Skulls

### DIFF
--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperHead.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperHead.java
@@ -41,7 +41,9 @@ class CreeperHead extends CreeperBlock
         newSkull.setRotation(skull.getRotation());
         newSkull.setSkullType(skull.getSkullType());
         if (skull.hasOwner())
-            newSkull.setOwningPlayer(skull.getOwningPlayer());
+            // Should be newSkull.setOwningPlayer(skull.getOwningPlayer()) instead of newSkull.setOwner(skull.getOwner())
+            // but skull.getOwningPlayer() somehow always returns null, so we need to use the deprecated method
+            newSkull.setOwner(skull.getOwner());
         newSkull.update(true);
     }
 
@@ -62,8 +64,8 @@ class CreeperHead extends CreeperBlock
             ItemStack s = new ItemStack(Material.SKULL_ITEM);
             SkullMeta m = (SkullMeta) s.getItemMeta();
             if (skull.hasOwner())
-                // Should be skull.getOwningPlayer().getName() instead of skull.getOwner();
-                // but somehow always returns null, so we need to use the deprecated method
+                // Should be skull.getOwningPlayer().getName() instead of skull.getOwner()
+                // but skull.getOwningPlayer() somehow always returns null, so we need to use the deprecated method
                 m.setOwner(skull.getOwner());
             s.setItemMeta(m);
             s.setDurability((short) skull.getSkullType().ordinal());

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperHead.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperHead.java
@@ -1,7 +1,13 @@
 package com.nitnelave.CreeperHeal.block;
 
+import com.nitnelave.CreeperHeal.config.CreeperConfig;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
 
 /**
  * Skull implementation of CreeperBlock, to store and replace the orientation,
@@ -37,6 +43,36 @@ class CreeperHead extends CreeperBlock
         if (skull.hasOwner())
             newSkull.setOwningPlayer(skull.getOwningPlayer());
         newSkull.update(true);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.nitnelave.CreeperHeal.block.CreeperBlock#drop(boolean)
+     */
+    @Override
+    public boolean drop(boolean forced)
+    {
+        if (forced || CreeperConfig.shouldDrop())
+        {
+            Location loc = blockState.getBlock().getLocation();
+            World w = loc.getWorld();
+
+            Skull skull = (Skull) blockState;
+            ItemStack s = new ItemStack(Material.SKULL_ITEM);
+            SkullMeta m = (SkullMeta) s.getItemMeta();
+            if (skull.hasOwner())
+                // Should be skull.getOwningPlayer().getName() instead of skull.getOwner();
+                // but somehow always returns null, so we need to use the deprecated method
+                m.setOwner(skull.getOwner());
+            s.setItemMeta(m);
+            s.setDurability((short) skull.getSkullType().ordinal());
+
+            w.dropItemNaturally(loc, s);
+
+            return true;
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
This should fix two bugs. On the one hand, that the owner of regenerated skulls is set correctly again. This does not happen at the moment because the method `[Skull].getOwningPlayer.getName()` always returns null, so that no owner can be assigned to the skull. On the other hand, that the SkullMeta was not transferred when skulls were dropped during regeneration.

____________________________
used MC-Version: 1.12
used Spigot build: Spigot-596221b-9a1fc1e (API: 1.12-R0.1-SNAPSHOT)