### PR TITLE
Correctly drop own BlockState drops when breaking

### DIFF
--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperBanner.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperBanner.java
@@ -1,39 +1,43 @@
 package com.nitnelave.CreeperHeal.block;
 
+import com.nitnelave.CreeperHeal.config.CreeperConfig;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Banner;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BannerMeta;
 
 /**
  * Banner implementation of CreeperBlock.
- * 
+ *
  * @author drexplosionpd
- * 
  */
 public class CreeperBanner extends CreeperBlock
 {
-	
+
     /*
      * Constructor.
      */
-    protected CreeperBanner(Banner banner)
+    CreeperBanner(Banner banner)
     {
         super(banner);
     }
 
     /*
-     * (non-Javadoc)
-     * 
-     * @see com.nitnelave.CreeperHeal.block.CreeperBlock#update()
+     * @see com.nitnelave.CreeperHeal.block.Replaceable#drop(boolean)
      */
     @Override
-    public void update()
+    public boolean drop(boolean forced)
     {
-        super.update();
-        Banner state = (Banner) getBlock().getState();
-        Banner banner = (Banner) blockState;
-        state.setBaseColor(banner.getBaseColor());
-        state.setPatterns(banner.getPatterns());
-
-        state.setData(banner.getData());
-        state.update(true);
+        if (forced || CreeperConfig.shouldDrop())
+        {
+            ItemStack itemStack = new ItemStack(blockState.getType());
+            BannerMeta bannerMeta = ((BannerMeta) Bukkit.getItemFactory().getItemMeta(blockState.getType()));
+            bannerMeta.setPatterns(((Banner) blockState).getPatterns());
+            itemStack.setItemMeta(bannerMeta);
+            blockState.getWorld().dropItemNaturally(blockState.getLocation().add(0.5, 0.5, 0.5), itemStack);
+            return true;
+        }
+        return false;
     }
+
 }

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperJukebox.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperJukebox.java
@@ -1,0 +1,85 @@
+package com.nitnelave.CreeperHeal.block;
+
+import com.nitnelave.CreeperHeal.CreeperHeal;
+import com.nitnelave.CreeperHeal.config.CreeperConfig;
+import com.nitnelave.CreeperHeal.config.WCfgVal;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Jukebox;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemSpawnEvent;
+
+/**
+ * Jukebox implementation of CreeperBlock.
+ *
+ * @author Jikoo
+ */
+public class CreeperJukebox extends CreeperBlock
+{
+
+    /*
+     * Constructor.
+     */
+    CreeperJukebox(Jukebox blockState)
+    {
+        super(blockState);
+        
+    }
+
+    /*
+     * In Minecraft 1.13, discs inserted into jukeboxes preserve item meta. Craftbukkit does not properly handle this.
+     * The only way to "prevent" the disc dropping is to remove it immediately after it spawns.
+     *
+     * @see com.nitnelave.CreeperHeal.block.Replaceable#remove()
+     */
+    @Override
+    public void remove()
+    {
+        Jukebox jukebox = ((Jukebox) blockState);
+
+        Listener recordDropListener = null;
+        
+        if (!CreeperConfig.getWorld(getWorld()).getBool(WCfgVal.DROP_CHEST_CONTENTS))
+        {
+            recordDropListener = new RecordDropListener(jukebox.getPlaying());
+            Bukkit.getPluginManager().registerEvents(recordDropListener, CreeperHeal.getInstance());
+        }
+
+        super.remove();
+
+        if (recordDropListener != null) {
+            HandlerList.unregisterAll(recordDropListener);
+        }
+    }
+
+    /*
+     * @see com.nitnelave.CreeperHeal.block.Replaceable#update()
+     */
+    @Override
+    public void update()
+    {
+        if (CreeperConfig.getWorld(getWorld()).getBool(WCfgVal.DROP_CHEST_CONTENTS))
+            blockState.getBlock().setType(Material.JUKEBOX);
+        else
+            super.update();
+    }
+
+    private class RecordDropListener implements Listener {
+
+        private final Material record;
+
+        private RecordDropListener(Material record) {
+            this.record = record;
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        public void onItemSpawn(ItemSpawnEvent event) {
+            if (event.getEntity().getItemStack().getType() == record) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperMultiblock.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperMultiblock.java
@@ -38,18 +38,18 @@ public abstract class CreeperMultiblock extends CreeperBlock
     @Override
     protected boolean checkForDrop()
     {
-        if (checkForDropHelper(getBlock()))
+        if (checkForDependentDrop(getBlock()))
             return true;
 
         for (BlockState dependent : dependents)
-            if (checkForDropHelper(dependent.getBlock()))
+            if (checkForDependentDrop(dependent.getBlock()))
                 return true;
 
         return false;
 
     }
 
-    private boolean checkForDropHelper(Block block)
+    private boolean checkForDependentDrop(Block block)
     {
         Material type = block.getType();
 

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperShulkerBox.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperShulkerBox.java
@@ -1,0 +1,51 @@
+package com.nitnelave.CreeperHeal.block;
+
+import com.nitnelave.CreeperHeal.config.CreeperConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+
+/**
+ * Shulker box implementation of CreeperBlock.
+ *
+ * @author Jikoo
+ */
+public class CreeperShulkerBox extends CreeperBlock
+{
+
+    CreeperShulkerBox(ShulkerBox blockState)
+    {
+        super(blockState);
+    }
+
+    /*
+     * @see com.nitnelave.CreeperHeal.block.Replaceable#drop(boolean)
+     */
+    @Override
+    public boolean drop(boolean forced)
+    {
+        if (forced || CreeperConfig.shouldDrop())
+        {
+            // Drop shulker with contents inside
+            ItemStack itemStack = new ItemStack(blockState.getType());
+            BlockStateMeta blockStateMeta = ((BlockStateMeta) Bukkit.getItemFactory().getItemMeta(Material.PURPLE_SHULKER_BOX));
+            blockStateMeta.setBlockState(blockState);
+            itemStack.setItemMeta(blockStateMeta);
+            blockState.getWorld().dropItemNaturally(blockState.getLocation().add(0.5, 0.5, 0.5), itemStack);
+            return true;
+        }
+        else
+        {
+            // Always drop container contents
+            Location location = blockState.getLocation().add(0.5, 0.5, 0.5);
+            for (ItemStack itemStack : ((ShulkerBox) blockState).getInventory().getContents()) {
+                blockState.getWorld().dropItemNaturally(location, itemStack);
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperShulkerBox.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperShulkerBox.java
@@ -1,12 +1,12 @@
 package com.nitnelave.CreeperHeal.block;
 
 import com.nitnelave.CreeperHeal.config.CreeperConfig;
-import org.bukkit.Bukkit;
+import com.nitnelave.CreeperHeal.config.WCfgVal;
 import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.ShulkerBox;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BlockStateMeta;
 
 /**
  * Shulker box implementation of CreeperBlock.
@@ -16,9 +16,12 @@ import org.bukkit.inventory.meta.BlockStateMeta;
 public class CreeperShulkerBox extends CreeperBlock
 {
 
+    private final ItemStack[] contents;
+
     CreeperShulkerBox(ShulkerBox blockState)
     {
         super(blockState);
+        this.contents = blockState.getInventory().getContents();
     }
 
     /*
@@ -27,25 +30,33 @@ public class CreeperShulkerBox extends CreeperBlock
     @Override
     public boolean drop(boolean forced)
     {
+        Location location = blockState.getLocation().add(0.5, 0.5, 0.5);
         if (forced || CreeperConfig.shouldDrop())
         {
             // Drop shulker with contents inside
             ItemStack itemStack = new ItemStack(blockState.getType());
-            BlockStateMeta blockStateMeta = ((BlockStateMeta) Bukkit.getItemFactory().getItemMeta(Material.PURPLE_SHULKER_BOX));
-            blockStateMeta.setBlockState(blockState);
-            itemStack.setItemMeta(blockStateMeta);
-            blockState.getWorld().dropItemNaturally(blockState.getLocation().add(0.5, 0.5, 0.5), itemStack);
-            return true;
+            blockState.getWorld().dropItemNaturally(location, itemStack);
         }
-        else
-        {
-            // Always drop container contents
-            Location location = blockState.getLocation().add(0.5, 0.5, 0.5);
-            for (ItemStack itemStack : ((ShulkerBox) blockState).getInventory().getContents()) {
-                blockState.getWorld().dropItemNaturally(location, itemStack);
-            }
+        // Always drop container contents
+        for (ItemStack itemStack : contents) {
+            if (itemStack == null)
+                continue;
+            blockState.getWorld().dropItemNaturally(location, itemStack);
         }
         return false;
+    }
+
+    @Override
+    public void update()
+    {
+        super.update();
+
+        if (CreeperConfig.getWorld(getWorld()).getBool(WCfgVal.DROP_CHEST_CONTENTS))
+            return;
+
+        BlockState newState = blockState.getBlock().getState();
+        if (newState instanceof InventoryHolder)
+            ((InventoryHolder) newState).getInventory().setContents(contents);
     }
 
 }


### PR DESCRIPTION
This PR fixes major dupe bugs related to incorrect blocks being dropped when using config options `overwrite-blocks` and `drop-destroyed-blocks`.

Still needs testing on 1.11/12, I just want to start discussion.

I'm worried that shulker boxes will suffer the same issues that other containers did - primary inventory required a somewhat hacky workaround to restore properly.

Per discussion in #61, I also need to revisit CreeperBlock#checkForDrop:
>Remove this function, and turn the checkForDrop function in CreeperBlock static, it's the same.

>It's not quite as simple as making it static - CreeperBlock#checkForDrop also calls CreeperBlock#drop conditionally.