### PR TITLE
Properly restore ArmorStands' gear

### DIFF
--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
@@ -36,8 +36,7 @@ public class CreeperArmorStand implements Replaceable
     @Override
     public boolean replace(boolean shouldDrop)
     {
-        ArmorStand s = getWorld()
-                .spawn(getLocation().getBlock().getRelative(BlockFace.DOWN).getLocation(), ArmorStand.class);
+        ArmorStand s = getWorld().spawn(getLocation(), ArmorStand.class);
         s.setArms(stand.hasArms());
         s.setBasePlate(stand.hasBasePlate());
         s.setBodyPose(stand.getBodyPose());

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
@@ -1,7 +1,9 @@
 package com.nitnelave.CreeperHeal.block;
 
+import com.nitnelave.CreeperHeal.CreeperHeal;
 import com.nitnelave.CreeperHeal.config.CreeperConfig;
 import com.nitnelave.CreeperHeal.utils.CreeperLog;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -39,7 +41,7 @@ public class CreeperArmorStand implements Replaceable
     @Override
     public boolean replace(boolean shouldDrop)
     {
-        ArmorStand s = getWorld().spawn(getLocation(), ArmorStand.class);
+        final ArmorStand s = getWorld().spawn(stand.getLocation(), ArmorStand.class);
         s.setArms(stand.hasArms());
         s.setBasePlate(stand.hasBasePlate());
         s.setBodyPose(stand.getBodyPose());
@@ -61,7 +63,15 @@ public class CreeperArmorStand implements Replaceable
         equipment.setItemInMainHand(this.mainHand);
         equipment.setItemInOffHand(this.offHand);
 
-        s.teleport(stand.getLocation());
+        Bukkit.getScheduler().runTask(CreeperHeal.getInstance(), new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                s.teleport(stand.getLocation());
+            }
+        });
+
         return true;
     }
 

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
@@ -10,8 +10,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 
 /**
  * Represents an ArmorStand
@@ -19,16 +18,18 @@ import java.util.Collections;
 public class CreeperArmorStand implements Replaceable
 {
     private final ArmorStand stand;
-    private ArrayList<ItemStack> contents = new ArrayList<ItemStack>();
+    private final ItemStack[] contents;
     private boolean wasRemoved = false;
 
     public CreeperArmorStand(ArmorStand stand)
     {
         this.stand = stand;
-        Collections.addAll(contents,
-                           stand.getBoots(), stand.getChestplate(), stand.getHelmet(), stand.getItemInHand(),
-                           stand.getLeggings());
-        CreeperLog.debug("Armor: " + contents);
+        this.contents = new ItemStack[]
+                { 
+                        stand.getHelmet(), stand.getChestplate(), stand.getLeggings(), stand.getBoots(),
+                        stand.getItemInHand()
+                };
+        CreeperLog.debug("Armor: " + Arrays.toString(contents));
         remove();
     }
 
@@ -40,19 +41,24 @@ public class CreeperArmorStand implements Replaceable
         s.setArms(stand.hasArms());
         s.setBasePlate(stand.hasBasePlate());
         s.setBodyPose(stand.getBodyPose());
-        s.setBoots(stand.getBoots());
-        s.setChestplate(stand.getChestplate());
+        s.setCustomName(stand.getCustomName());
+        s.setCustomNameVisible(stand.isCustomNameVisible());
+        s.setGlowing(stand.isGlowing());
+        s.setGravity(stand.hasGravity());
         s.setHeadPose(stand.getHeadPose());
-        s.setHelmet(stand.getHelmet());
-        s.setItemInHand(stand.getItemInHand());
         s.setLeftArmPose(stand.getLeftArmPose());
         s.setRightArmPose(stand.getRightArmPose());
         s.setLeftLegPose(stand.getLeftLegPose());
         s.setRightLegPose(stand.getRightLegPose());
-        s.setLeggings(stand.getLeggings());
         s.setMarker(stand.isMarker());
         s.setSmall(stand.isSmall());
         s.setVisible(stand.isVisible());
+
+        s.setHelmet(contents[0]);
+        s.setChestplate(contents[1]);
+        s.setLeggings(contents[2]);
+        s.setBoots(contents[3]);
+        s.setItemInHand(contents[4]);
 
         s.teleport(stand.getLocation());
         return true;
@@ -100,9 +106,9 @@ public class CreeperArmorStand implements Replaceable
         if (forced || CreeperConfig.shouldDrop())
         {
             getWorld().dropItemNaturally(getLocation(), new ItemStack(Material.ARMOR_STAND, 1));
-            for (ItemStack s : contents)
-                if (s.getType() != Material.AIR)
-                    getWorld().dropItemNaturally(getLocation(), s);
+            for (ItemStack itemStack : contents)
+                if (itemStack != null && itemStack.getType() != Material.AIR)
+                    getWorld().dropItemNaturally(getLocation(), itemStack);
             return true;
         }
         return false;

--- a/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
+++ b/src/main/java/com/nitnelave/CreeperHeal/block/CreeperArmorStand.java
@@ -8,6 +8,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
@@ -18,17 +19,19 @@ import java.util.Arrays;
 public class CreeperArmorStand implements Replaceable
 {
     private final ArmorStand stand;
+    private final ItemStack mainHand, offHand;
     private final ItemStack[] contents;
     private boolean wasRemoved = false;
 
-    public CreeperArmorStand(ArmorStand stand)
+    CreeperArmorStand(ArmorStand stand)
     {
         this.stand = stand;
-        this.contents = new ItemStack[]
-                { 
-                        stand.getHelmet(), stand.getChestplate(), stand.getLeggings(), stand.getBoots(),
-                        stand.getItemInHand()
-                };
+        EntityEquipment equipment = stand.getEquipment();
+        this.mainHand = equipment.getItemInMainHand();
+        this.offHand = equipment.getItemInOffHand();
+
+        this.contents = new ItemStack[equipment.getArmorContents().length];
+        System.arraycopy(equipment.getArmorContents(), 0, contents, 0, contents.length);
         CreeperLog.debug("Armor: " + Arrays.toString(contents));
         remove();
     }
@@ -53,11 +56,10 @@ public class CreeperArmorStand implements Replaceable
         s.setSmall(stand.isSmall());
         s.setVisible(stand.isVisible());
 
-        s.setHelmet(contents[0]);
-        s.setChestplate(contents[1]);
-        s.setLeggings(contents[2]);
-        s.setBoots(contents[3]);
-        s.setItemInHand(contents[4]);
+        EntityEquipment equipment = s.getEquipment();
+        equipment.setArmorContents(contents);
+        equipment.setItemInMainHand(this.mainHand);
+        equipment.setItemInOffHand(this.offHand);
 
         s.teleport(stand.getLocation());
         return true;
@@ -119,13 +121,7 @@ public class CreeperArmorStand implements Replaceable
         if (!wasRemoved)
         {
             wasRemoved = true;
-            ItemStack air = new ItemStack(Material.AIR);
-            stand.setChestplate(air);
-            stand.setHelmet(air);
-            stand.setLeggings(air);
-            stand.setBoots(air);
-            stand.setItemInHand(air);
-
+            stand.getEquipment().clear();
             CreeperLog.debug("Removing armor, chestplate = " + stand.getChestplate().getType());
             stand.remove();
         }


### PR DESCRIPTION
Tested and functioning on 1.11. ~~Will require another update for 1.12 for the off hand slot. I believe in 1.12+ ArmorStands are considered to actually have an inventory, so it should be possible to much more cleanly future-proof.~~
Off hand has been around since 1.9, somehow spaced on the correct method name.